### PR TITLE
update brew commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 ### Using [HomeBrew Cask](http://caskroom.github.io/)
 
-- install : ```brew cask install <package name>```
-- uninstall : ```brew cask uninstall <package name>```
+- install : ```brew install --cask <package name>```
+- uninstall : ```brew uninstall --cask <package name>```
 
 ### Manually
 - install : Move the downloaded .qlgenerator file to `~/Library/QuickLook` (only for yourself) or `/Library/QuickLook` (for everyone)


### PR DESCRIPTION
brew recently disabled the `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524